### PR TITLE
fix: configure non-interactive mode for test resources and field-resolution validation

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -123,6 +123,10 @@ def test_something(monkeypatch):
 
 This covers the vast majority of tests. No file I/O, no environment-specific setup needed.
 
+!!! success "`for_session() + monkeypatch` is NOT a fallback"
+    `for_session()` + `monkeypatch` is for isolated unit tests where only config *values* matter, not config *source*. It **MUST NEVER** be used to paper over missing configuration in CI or local dev. If a code path needs `get_config()`/`load_stack_config()` to succeed at all, you
+    need to provide a real configuration for the test case.
+
 ### Integration tests: dedicated test resource
 
 For tests that exercise a real database (e.g. PostgreSQL-specific SQL, bulk loading, trigger
@@ -133,27 +137,20 @@ The canonical resource name is `test_<package>_db` (e.g. `test_cdm_db` for omop-
 Keeping the name distinct from the production resource (`cdm_db`) is a mandatory safety guard:
 the test suite must never accidentally connect to a production database.
 
-In `conftest.py`, resolve the test resource explicitly:
+In `conftest.py`, resolve the test resource via the `resolve_test_resource` pytest-plugin
+helper, which skips cleanly whether `config.toml` is entirely missing or simply
+doesn't have this resource configured yet:
 
 ```python
-_TEST_RESOURCE = "test_cdm_db"
-
 @pytest.fixture(scope="session")
 def pg_engine():
-    # CI: sets ENGINE_CDM env var no file I/O needed
-    url = os.getenv("ENGINE_CDM")
-    if url:
-        return sa.create_engine(url, future=True)
+    from oa_configurator.pytest_plugin import resolve_test_resource
+    from my_package.config import MyPackageConfig
 
-    # Local Dev:  read dedicated test resource from config
-    from oa_configurator import Resolver, load_stack_config
-    from oa_configurator.package_base import ConfigurationError
-    try:
-        stack = load_stack_config()
-        resolved = Resolver(stack).resolve_resource(_TEST_RESOURCE)
-        return resolved.create_engine()
-    except (FileNotFoundError, KeyError, ConfigurationError):
-        pytest.skip("No PostgreSQL test database configured.")
+    url = resolve_test_resource(MyPackageConfig.TEST_DB)
+    engine = sa.create_engine(url, future=True)
+    yield engine
+    engine.dispose()
 ```
 
 **Why not `OA_ACTIVE_PROFILE=test`?** Setting `OA_ACTIVE_PROFILE` globally in `conftest.py`
@@ -161,26 +158,39 @@ affects every test that calls `load_stack_config()`, including unit tests that m
 A dedicated resource name scopes the real-DB resolution to only the fixture that needs it, and
 leaves `cdm_db` unambiguously pointing at production data throughout the test session.
 
-Add the test resource to `~/.config/omop/config.toml`:
+#### Provisioning the test resource
 
-```toml
-[databases.pg_test]
-dialect       = "postgresql+psycopg"
-host          = "localhost"
-port          = 5432
-user          = "test"
-password      = "test"
-database_name = "test_db"
+The test resource must be provisioned for real before pytest runs. There is no fallback that
+papers over a missing one, by design (see the callout above). `omop-config configure <package>`
+accepts `--test-*` flags (mirroring every owned-resource flag, e.g. `--test-host`, `--test-port`,
+`--test-database-name`) for exactly this:
 
-[resources.test_cdm_db]
-database   = "pg_test"
-cdm_schema = "public"
-```
+=== "Local development"
 
-> **Safety**: the test resource must point to a dedicated, empty database.
-> If your test session drops and recreates schemas, add a runtime guard that compares the
-> resolved URL of `test_cdm_db` against all other configured resources and calls
-> `pytest.fail()` on any match.
+    Run `omop-config configure <package>` and answer `Y` when asked to configure a
+    test database resource, or pass `--test-*` flags directly for the same one-shot, non-interactive 
+    result CI uses.
+
+=== "CI"
+
+    pass `--test-*` flags as part of the same `omop-config configure <package>` step that
+    configures the package's owned resource (if it has one):
+
+    ```bash
+    omop-config configure <db-package> \
+      --test-dialect postgresql+psycopg --test-database test_cdm \
+      --test-host localhost --test-port 5432 --test-cdm-schema public \
+      --test-user test --test-password test --test-database-name test_db
+    ```
+    `--test-*` flags work independently of the owned resource flags. This 
+    means that we can just provide the test flags if the resource itself is
+    not needed in the CI but the test configuration is.
+
+!!! info "Safety"
+    The test resource must point to a dedicated, empty database.
+    If your test session drops and recreates schemas, add a runtime guard that compares the
+    resolved URL of `test_cdm_db` against all other configured resources and calls
+    `pytest.fail()` on any match.
 
 ---
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -163,7 +163,8 @@ leaves `cdm_db` unambiguously pointing at production data throughout the test se
 The test resource must be provisioned for real before pytest runs. There is no fallback that
 papers over a missing one, by design (see the callout above). `omop-config configure <package>`
 accepts `--test-*` flags (mirroring every owned-resource flag, e.g. `--test-host`, `--test-port`,
-`--test-database-name`) for exactly this:
+`--test-database-name`) for exactly this. The `test-` prefix is fixed and the same for every
+package; it is not configurable per package.
 
 === "Local development"
 

--- a/src/oa_configurator/__init__.py
+++ b/src/oa_configurator/__init__.py
@@ -1,5 +1,19 @@
 """Public package surface for ``oa-configurator``."""
 
+from .cli_fields import (
+    FieldSpec,
+    FS_CDM_SCHEMA,
+    FS_DATABASE,
+    FS_DATABASE_NAME,
+    FS_DIALECT,
+    FS_HOST,
+    FS_NON_CDM_SCHEMA,
+    FS_PASSWORD,
+    FS_PORT,
+    FS_RESULTS_SCHEMA,
+    FS_USER,
+    FS_VOCAB_SCHEMA,
+)
 from .io import FLAT_ENV_PATH, patch_active_profile, save_stack_config, write_env_file
 from .loader import DEFAULT_CONFIG_PATH, load_stack_config
 from .logging_config import LoggingConfig, RedactingFormatter, configure_logging, get_logger
@@ -17,6 +31,18 @@ __all__ = [
     "ConfigurationError",
     "DEFAULT_CONFIG_PATH",
     "FLAT_ENV_PATH",
+    "FS_CDM_SCHEMA",
+    "FS_DATABASE",
+    "FS_DATABASE_NAME",
+    "FS_DIALECT",
+    "FS_HOST",
+    "FS_NON_CDM_SCHEMA",
+    "FS_PASSWORD",
+    "FS_PORT",
+    "FS_RESULTS_SCHEMA",
+    "FS_USER",
+    "FS_VOCAB_SCHEMA",
+    "FieldSpec",
     "DatabaseConfig",
     "LoggingConfig",
     "RedactingFormatter",

--- a/src/oa_configurator/cli.py
+++ b/src/oa_configurator/cli.py
@@ -641,7 +641,12 @@ def verify(
     all_ok = True
 
     for name in sorted(config.databases):
-        target = resolver.resolve_database(name)
+        try:
+            target = resolver.resolve_database(name)
+        except Exception as exc:
+            table.add_row(name, "?", "[red]FAIL[/red]", str(exc)[:60])
+            all_ok = False
+            continue
         try:
             t0 = time.monotonic()
             engine = target.create_engine()

--- a/src/oa_configurator/cli.py
+++ b/src/oa_configurator/cli.py
@@ -215,7 +215,7 @@ class _DynamicConfigureGroup(TyperGroup):
     def list_commands(self, ctx):
         return sorted(ep.name for ep in entry_points(group="omop.config"))
 
-    def get_command(self, ctx, cmd_name):
+    def get_command(self, ctx, cmd_name):  # type: ignore 
         eps = {ep.name: ep for ep in entry_points(group="omop.config")}
         ep = eps.get(cmd_name)
         return _build_package_command(cmd_name, ep.load()) if ep else None
@@ -374,7 +374,7 @@ def _run_configure_package(
     save_stack_config(config)
     console.print(f"\n[green]✓[/green] Saved \\[tools.{tool_name}] to [dim]{CONFIG_PATH}[/dim]")
 
-    if cls.test_resources:
+    if cls.test_resources and flags_arg is None:
         console.print("\n[dim]─── Test database (optional) ───[/dim]")
         console.print(
             "[yellow]⚠[/yellow]  Test resources are used by the test suite, which runs"

--- a/src/oa_configurator/cli.py
+++ b/src/oa_configurator/cli.py
@@ -25,9 +25,11 @@ from .cli_fields import (
     CDM_SCHEMA_FIELDS,
     DATABASE_LABEL_FIELDS,
     NON_CDM_SCHEMA_FIELDS,
+    TEST_FLAG_PREFIX,
     build_database_config,
     build_resource_config,
     build_resource_params,
+    flag_name,
     resolve_field_value,
     resolve_fields,
 )
@@ -105,11 +107,15 @@ def _resolve_resource(
 
     missing_required: list[str] = []
 
+    spec_defaults = (
+        {k: str(v) for k, v in spec.connection_defaults.model_dump(exclude_unset=True).items()}
+        if spec.connection_defaults else None
+    )
     _resolve_field = partial(
         resolve_field_value,
         flags=flags,
         stored=_stored,
-        spec_defaults=spec.defaults,
+        spec_defaults=spec_defaults,
         non_interactive=non_interactive,
         missing_required=missing_required,
     )
@@ -172,16 +178,16 @@ def _check_missing_required(
         Field names appended to by resolve_field_value while resolving spec. Empty
         means nothing is missing.
     is_test_resource : bool
-        Whether spec is a test resource, controls the ``--test-`` flag prefix shown
-        in the error message.
+        Whether spec is a test resource, selects TEST_FLAG_PREFIX for the flag names
+        shown in the error message.
     non_interactive : bool
         Whether this resolution was non-interactive. Interactive resolutions never
         have anything in missing_required, since prompting always produces a value.
     """
     if not non_interactive or not missing_required:
         return
-    prefix = "--test-" if is_test_resource else "--"
-    flag_names = ", ".join(f"{prefix}{k.replace('_', '-')}" for k in missing_required)
+    prefix = TEST_FLAG_PREFIX if is_test_resource else ""
+    flag_names = ", ".join(flag_name(k, prefix) for k in missing_required)
     err_console.print(
         f"\n[red bold]Missing required field(s) for {spec.display_name!r}:[/red bold] {flag_names}\n"
         f"No flag, stored config, or spec default is available for these. Pass them explicitly."
@@ -260,7 +266,7 @@ def _build_extra_params(cls) -> list[click.Parameter]:
     """Generate Click options for a package's extra fields from its model_fields."""
     return [
         click.Option(
-            [f"--{name.replace('_', '-')}"],
+            [flag_name(name)],
             default=None,
             type=click.STRING,
             help=info.description or "",
@@ -273,7 +279,7 @@ def _build_package_command(ep_name: str, cls) -> click.Command:
     """Build a Click command for one registered package entry point."""
     resource_params = [p for spec in cls.owned_resources for p in build_resource_params(spec)]
     test_resource_params = [
-        p for spec in cls.test_resources for p in build_resource_params(spec, prefix="test-")
+        p for spec in cls.test_resources for p in build_resource_params(spec, prefix=TEST_FLAG_PREFIX)
     ]
     extra_params = _build_extra_params(cls)
     resource_names = {p.name for p in resource_params}

--- a/src/oa_configurator/cli.py
+++ b/src/oa_configurator/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from functools import partial
 from importlib.metadata import entry_points
 from typing import Annotated
 
@@ -20,6 +21,16 @@ from .logging_config import configure_logging
 from .models import DatabaseConfig, ResourceConfig, StackConfig, ToolConfig
 from .package_base import ConfigurationError, ResourceSpec
 from .resolver import Resolver
+from .cli_fields import (
+    CDM_SCHEMA_FIELDS,
+    DATABASE_LABEL_FIELDS,
+    NON_CDM_SCHEMA_FIELDS,
+    build_database_config,
+    build_resource_config,
+    build_resource_params,
+    resolve_field_value,
+    resolve_fields,
+)
 
 app = typer.Typer(name="omop-config", no_args_is_help=True, add_completion=False)
 console = Console()
@@ -36,28 +47,34 @@ def _resolve_resource(
 ) -> tuple[str, DatabaseConfig | None, ResourceConfig] | None:
     """Resolve or create a database config + resource for a ResourceSpec.
 
-    Resolution order for each field: explicit flag > stored config > prompt.
-
-    When *flags* is provided, the "keep existing?" confirmation is suppressed.
-    This is the non-interactive path suitable for scripted / Docker Compose use.
-    Omitting *flags* preserves fully-interactive behaviour.
-
     Parameters
     ----------
-    spec
-        The ResourceSpec describing the resource to configure.
-    config
-        The current StackConfig, used to look up existing config and determine defaults.
-    flags
-        Optional dict of flag values to override prompts.
-        Keys correspond to the fields of DatabaseConfig and ResourceConfig.
-    semantic_name_override
-        When provided, the resource is created/updated under this name instead
-        of ``spec.semantic_name``. Used by ``--resource-name`` to create a
-        second instance of the same resource type (e.g. ``cdm_db_prod``).
-
-    Returns ``(db_name, db_config, resource)`` or ``None`` to keep existing config.
-    When an existing connection is reused, ``db_config`` is ``None`` (no new entry needed).
+    spec : ResourceSpec
+        The ResourceSpec describing the resource to resolve.
+    config : StackConfig
+        The current StackConfig, used to look up existing stored config for 
+        this resource and any existing connections.
+    flags : dict[str, str], optional
+        A dict of flag values for this resource, keyed by field name
+        (e.g. "host", "port"). Presence of this argument (even if empty) 
+        indicates a non-interactive invocation where no prompts should be shown.
+        Non-interactive requires all required fields to be supplied via flags or
+        stored config. Missing required fields will be reported.
+    semantic_name_override: str, optional
+        When given, this name is used instead of spec.semantic_name for looking up
+        existing config and for the saved resource name.
+    is_test_resource: bool
+        Whether this resource is a test resource. If True, the safety checks around
+        test resources are applied (see _configure_test_resources). Default: False
+    
+    Returns
+    -------
+    db_name : str
+        The name of the database config to use for this resource (either existing or new).
+    db_config : DatabaseConfig, optional
+        The new DatabaseConfig to save for this resource, or None to reuse an existing one.
+    resource : ResourceConfig
+        The ResourceConfig to save for this resource (either existing with updates or new).
     """
     non_interactive = flags is not None
     flags = flags or {}
@@ -79,12 +96,6 @@ def _resolve_resource(
         console.print(f"[dim]{spec.description}[/dim]")
         console.print("[dim]Tip: the value shown in [brackets] is the default. Press Enter to accept it.[/dim]\n")
 
-    # Resolution order: explicit flag > stored config > prompt.
-    # _stored holds every field from the existing config as strings ("" for None)
-    # so _v can find them and skip the prompt. Callers do `_v(...) or None` to
-    # convert empty-string back to None for optional fields.
-    # When the user explicitly declined to keep the existing config, we don't
-    # pre-fill _stored — they should be prompted for every field afresh.
     _stored: dict[str, str] = {}
     if existing and not declined:
         _stored.update({k: str(v) if v is not None else "" for k, v in existing.model_dump().items()})
@@ -92,17 +103,19 @@ def _resolve_resource(
         if _edb:
             _stored.update({k: str(v) if v is not None else "" for k, v in _edb.model_dump().items()})
 
-    def _v(key: str, label: str, default: str, *, hide_input: bool = False) -> str:
-        if (val := flags.get(key)) is not None:
-            return str(val)
-        if key in _stored:
-            return _stored[key]
-        if spec.defaults and (pre := spec.defaults.get(key)) is not None:
-            default = str(pre)
-        return typer.prompt(label, default=default, hide_input=hide_input)
+    missing_required: list[str] = []
+
+    _resolve_field = partial(
+        resolve_field_value,
+        flags=flags,
+        stored=_stored,
+        spec_defaults=spec.defaults,
+        non_interactive=non_interactive,
+        missing_required=missing_required,
+    )
 
     # Offer reuse of an existing connection when none is configured yet.
-    reuse_label: str | None = None
+    reuse_existing_label: str | None = None
     if not existing and not non_interactive and config.databases:
         if is_test_resource:
             candidates = [n for n, db in config.databases.items() if db.test_only]
@@ -117,60 +130,63 @@ def _resolve_resource(
                 default=suggested,
             )
             if choice != "new" and choice in candidates:
-                reuse_label = choice
+                reuse_existing_label = choice
 
-    if reuse_label:
+    schema_fields = CDM_SCHEMA_FIELDS if spec.is_cdm_database else NON_CDM_SCHEMA_FIELDS
+
+    if reuse_existing_label:
         if not non_interactive:
             console.print("\n[dim]Schema configuration[/dim]\n")
-        if spec.is_cdm_database:
-            cdm_schema = _v("cdm_schema", "CDM schema  (schema containing the OMOP tables)", spec.cdm_schema_default)
-            vocab_schema = _v("vocab_schema", "Vocab schema  (blank = same schema as CDM; set only if vocabulary lives in a separate schema)", "") or None
-            results_schema = _v("results_schema", "Results schema  (for Achilles/Atlas results tables; blank = not used)", "") or None
-        else:
-            cdm_schema = _v("cdm_schema", "Schema  (leave blank for public/default)", spec.cdm_schema_default)
-            vocab_schema = None
-            results_schema = None
-        resource = ResourceConfig(
-            database=reuse_label,
-            cdm_schema=cdm_schema,
-            vocab_schema=vocab_schema,
-            results_schema=results_schema,
-        )
-        return reuse_label, None, resource
+        schema_values = resolve_fields(schema_fields, spec, _resolve_field)
+        _check_missing_required(spec, missing_required, is_test_resource, non_interactive)
+        resource = build_resource_config(reuse_existing_label, schema_values, spec.is_cdm_database)
+        return reuse_existing_label, None, resource
 
-    database = _v("database", "Database label  (short name for this database entry, e.g. 'cdm')", spec.connection_name_hint or "cdm")
-    dialect = _v("dialect", "Dialect  (SQLAlchemy driver string, e.g. postgresql+psycopg, sqlite)", "postgresql+psycopg")
-    host = _v("host", "Host  (e.g. Docker container name; leave blank for SQLite or socket connections)", "localhost") or None
-
-    port_str = _v("port", "Port  (leave blank to use the dialect default)", "")
-    port: int | None = int(port_str) if port_str.strip() else None
-
-    user = _v("user", "User  (leave blank if not required)", "") or None
-    password = _v("password", "Password  (leave blank if not required)", "", hide_input=True) or None
-    database_name = _v("database_name", "Database name  (name of the database on the server, or file path for SQLite)", "") or None
-
-    db_config = DatabaseConfig(dialect=dialect, host=host, port=port, user=user, password=password, database_name=database_name)
+    conn_values = resolve_fields(DATABASE_LABEL_FIELDS, spec, _resolve_field)
 
     if not non_interactive:
         console.print("\n[dim]Schema configuration[/dim]\n")
 
-    if spec.is_cdm_database:
-        cdm_schema = _v("cdm_schema", "CDM schema  (schema containing the OMOP tables)", spec.cdm_schema_default)
-        vocab_schema = _v("vocab_schema", "Vocab schema  (blank = same schema as CDM; set only if vocabulary lives in a separate schema)", "") or None
-        results_schema = _v("results_schema", "Results schema  (for Achilles/Atlas results tables; blank = not used)", "") or None
-    else:
-        cdm_schema = _v("cdm_schema", "Schema  (leave blank for public/default)", spec.cdm_schema_default)
-        vocab_schema = None
-        results_schema = None
+    schema_values = resolve_fields(schema_fields, spec, _resolve_field)
+    _check_missing_required(spec, missing_required, is_test_resource, non_interactive)
 
-    resource = ResourceConfig(
-        database=database,
-        cdm_schema=cdm_schema,
-        vocab_schema=vocab_schema,
-        results_schema=results_schema,
-    )
+    db_config, database = build_database_config(conn_values)
+    resource = build_resource_config(database, schema_values, spec.is_cdm_database)
 
     return database, db_config, resource
+
+
+def _check_missing_required(
+    spec: ResourceSpec,
+    missing_required: list[str],
+    is_test_resource: bool,
+    non_interactive: bool,
+) -> None:
+    """Abort with a clear error if a non-interactive resolution left required fields unset.
+
+    Parameters
+    ----------
+    spec : ResourceSpec
+        The resource being resolved, used for the display name in the error message.
+    missing_required : list[str]
+        Field names appended to by resolve_field_value while resolving spec. Empty
+        means nothing is missing.
+    is_test_resource : bool
+        Whether spec is a test resource, controls the ``--test-`` flag prefix shown
+        in the error message.
+    non_interactive : bool
+        Whether this resolution was non-interactive. Interactive resolutions never
+        have anything in missing_required, since prompting always produces a value.
+    """
+    if not non_interactive or not missing_required:
+        return
+    prefix = "--test-" if is_test_resource else "--"
+    flag_names = ", ".join(f"{prefix}{k.replace('_', '-')}" for k in missing_required)
+    err_console.print(
+        f"\n[red bold]Missing required field(s) for {spec.display_name!r}:[/red bold] {flag_names}\n"
+        f"No flag, stored config, or spec default is available for these. Pass them explicitly."
+    )
+    raise typer.Exit(1)
 
 
 def _resolve_extra_fields(
@@ -180,7 +196,26 @@ def _resolve_extra_fields(
     set_dict: dict[str, str],
     interactive: bool,
 ) -> dict:
-    """Resolve package-specific extra fields using flag (--set) → stored → prompt."""
+    """Resolve package-specific extra fields using flag (--set) then stored then prompt.
+
+    Parameters
+    ----------
+    cls
+        The package's PackageConfigBase subclass, whose model_fields are resolved.
+    config : StackConfig
+        The current StackConfig, used to read any already-stored extras.
+    set_dict : dict[str, str]
+        Flag values from ``--set``, keyed by field name. Checked first.
+    interactive : bool
+        Whether to prompt for fields not covered by set_dict or stored config.
+        Non-interactively, such fields are simply omitted (they fall back to the
+        field's own pydantic default when the config class is loaded).
+
+    Returns
+    -------
+    dict
+        Resolved extra field values, keyed by field name.
+    """
     try:
         current = cls.from_stack(config)
         current_dict = current.to_extra_dict()
@@ -221,32 +256,6 @@ class _DynamicConfigureGroup(TyperGroup):
         return _build_package_command(cmd_name, ep.load()) if ep else None
 
 
-def _build_resource_params(spec: ResourceSpec) -> list[click.Parameter]:
-    """Generate Click options for one resource from DatabaseConfig + ResourceConfig fields."""
-    params: list[click.Parameter] = []
-    for name, info in DatabaseConfig.model_fields.items():
-        if name in ("read_only", "test_only"):
-            continue
-        params.append(click.Option(
-            [f"--{name.replace('_', '-')}"],
-            default=None,
-            type=click.STRING,
-            help=info.description or "",
-        ))
-    resource_field_names = ["database", "cdm_schema"]
-    if spec.is_cdm_database:
-        resource_field_names += ["vocab_schema", "results_schema"]
-    for name in resource_field_names:
-        info = ResourceConfig.model_fields[name]
-        params.append(click.Option(
-            [f"--{name.replace('_', '-')}"],
-            default=None,
-            type=click.STRING,
-            help=info.description or "",
-        ))
-    return params
-
-
 def _build_extra_params(cls) -> list[click.Parameter]:
     """Generate Click options for a package's extra fields from its model_fields."""
     return [
@@ -262,9 +271,13 @@ def _build_extra_params(cls) -> list[click.Parameter]:
 
 def _build_package_command(ep_name: str, cls) -> click.Command:
     """Build a Click command for one registered package entry point."""
-    resource_params = [p for spec in cls.owned_resources for p in _build_resource_params(spec)]
+    resource_params = [p for spec in cls.owned_resources for p in build_resource_params(spec)]
+    test_resource_params = [
+        p for spec in cls.test_resources for p in build_resource_params(spec, prefix="test-")
+    ]
     extra_params = _build_extra_params(cls)
     resource_names = {p.name for p in resource_params}
+    test_resource_names = {p.name for p in test_resource_params}
     extra_names = {p.name for p in extra_params}
 
     resource_name_opt = click.Option(
@@ -279,14 +292,18 @@ def _build_package_command(ep_name: str, cls) -> click.Command:
     def callback(**kwargs):
         flags_arg = {k: str(v) for k, v in kwargs.items()
                      if k in resource_names and v is not None} or None
+        test_flags_arg = {
+            k[len("test_"):]: str(v) for k, v in kwargs.items()
+            if k in test_resource_names and v is not None
+        } or None
         set_dict = {k: str(v) for k, v in kwargs.items()
                     if k in extra_names and v is not None}
-        _run_configure_package(cls, flags_arg, set_dict, kwargs.get("resource_name"))
+        _run_configure_package(cls, flags_arg, set_dict, kwargs.get("resource_name"), test_flags_arg)
 
     return click.Command(
         name=ep_name,
         callback=callback,
-        params=resource_params + extra_params + [resource_name_opt],
+        params=resource_params + test_resource_params + extra_params + [resource_name_opt],
         help=f"Configure {cls.tool_name} settings in config.toml.",
     )
 
@@ -306,14 +323,49 @@ def _list_packages() -> None:
         for name in sorted(registered):
             console.print(f"  • {name}")
 
-
 def _run_configure_package(
     cls,
     flags_arg: dict[str, str] | None,
     set_dict: dict[str, str],
     resource_name: str | None,
+    test_flags_arg: dict[str, str] | None = None,
 ) -> None:
-    """Run the configure flow for one package."""
+    """Run the configure flow for one package.
+
+    Parameters
+    ----------
+    cls
+        The package's PackageConfigBase subclass.
+    flags_arg : dict[str, str], optional
+        Flag values for the package's owned resource(s), keyed by field name.
+        None means no owned-resource flags were given on this invocation.
+    set_dict : dict[str, str]
+        Flag values for ``--set`` package extras, keyed by field name.
+    resource_name : str or None
+        Resource name override from ``--resource-name``.
+    test_flags_arg : dict[str, str] or None, optional
+        Flag values for the package's test resource(s), keyed by field name.
+        None means no ``--test-*`` flags were given. Default: None
+
+    Notes
+    -----
+    Interactivity is decided per resource, not globally. The invocation is
+    non-interactive as a whole the moment any of flags_arg, test_flags_arg or
+    set_dict is given, but that alone does not mean every resource is
+    touched:
+
+    1. The owned resource is only resolved when flags_arg is not None, i.e.
+       at least one of its own flags was given. An invocation with only
+       ``--test-*`` flags (e.g. a CI job that only needs a test database)
+       leaves the owned resource completely untouched, rather than prompting
+       for it (no TTY, would abort) or writing defaults nobody asked for.
+    2. The test resource is resolved non-interactively whenever
+       test_flags_arg is not None. The interactive prompt only fires 
+       for a fully bare invocation, with no flags anywhere.
+    3. Within a resource that is being resolved, individual missing fields
+       still fall back to stored config, a spec default, or a safe default
+       value. See _resolve_resource for which fields error out instead.
+    """
     try:
         config = load_stack_config()
     except FileNotFoundError:
@@ -324,7 +376,12 @@ def _run_configure_package(
     console.print(f"\n[bold]Configuring [cyan]{tool_name}[/cyan][/bold]")
     console.print(f"[dim]TOML section: \\[tools.{tool_name}][/dim]")
 
+
+    any_explicit_flags = flags_arg is not None or test_flags_arg is not None or bool(set_dict)
+
     for spec in cls.owned_resources:
+        if flags_arg is None and any_explicit_flags:
+            continue
         effective_name = resource_name if (resource_name and len(cls.owned_resources) == 1) else None
         result = _resolve_resource(spec, config, flags=flags_arg, semantic_name_override=effective_name)
         if result is not None:
@@ -345,7 +402,9 @@ def _run_configure_package(
                 f"It may be provided by another package. Run that package's configure command."
             )
 
-    extra = _resolve_extra_fields(cls, config, set_dict=set_dict, interactive=flags_arg is None)
+    extra = _resolve_extra_fields(
+        cls, config, set_dict=set_dict, interactive=flags_arg is None and not any_explicit_flags
+    )
 
     existing_tool = config.tools.get(tool_name)
     existing_default = existing_tool.default_resource if existing_tool else None
@@ -355,7 +414,7 @@ def _run_configure_package(
         relevant_names.add(resource_name)
     relevant_resources = [r for r in available_resources if r in relevant_names]
 
-    if len(relevant_resources) > 1 and flags_arg is None:
+    if len(relevant_resources) > 1 and flags_arg is None and not any_explicit_flags:
         console.print(f"\n[dim]Available resources for this package: {', '.join(relevant_resources)}[/dim]")
         prompt_default = resource_name or existing_default or relevant_resources[0]
         new_default_resource = (
@@ -365,7 +424,7 @@ def _run_configure_package(
             )
             or None
         )
-    elif len(relevant_resources) > 1 and flags_arg is not None:
+    elif len(relevant_resources) > 1:
         new_default_resource = resource_name or existing_default or relevant_resources[0]
     else:
         new_default_resource = existing_default or (relevant_resources[0] if relevant_resources else None)
@@ -374,61 +433,91 @@ def _run_configure_package(
     save_stack_config(config)
     console.print(f"\n[green]✓[/green] Saved \\[tools.{tool_name}] to [dim]{CONFIG_PATH}[/dim]")
 
-    if cls.test_resources and flags_arg is None:
-        console.print("\n[dim]─── Test database (optional) ───[/dim]")
-        console.print(
-            "[yellow]⚠[/yellow]  Test resources are used by the test suite, which runs"
-            " DROP SCHEMA CASCADE on every run.\n"
-            "   Point to a [bold]dedicated test_only connection[/bold], never to real data.\n"
-            "   Existing test_only connections will be offered for reuse."
-        )
-        want_test = typer.confirm("Configure a test database resource?", default=False)
-        if want_test:
-            test_names = {s.semantic_name for s in cls.test_resources}
-            for spec in cls.test_resources:
-                result = _resolve_resource(spec, config, flags=None, is_test_resource=True)
-                if result is None:
+    if cls.test_resources:
+        if test_flags_arg is not None:
+            _configure_test_resources(cls, config, test_flags_arg)
+        elif not any_explicit_flags:
+            console.print("\n[dim]─── Test database (optional) ───[/dim]")
+            console.print(
+                "[yellow]⚠[/yellow]  Test resources are used by the test suite, which runs"
+                " DROP SCHEMA CASCADE on every run.\n"
+                "   Point to a [bold]dedicated test_only connection[/bold], never to real data.\n"
+                "   Existing test_only connections will be offered for reuse."
+            )
+            want_test = typer.confirm("Configure a test database resource?", default=False)
+            if want_test:
+                _configure_test_resources(cls, config, None)
+        # else: any_explicit_flags is True but no --test-* flags were given.
+        # Test resources are opt-in, so leave them untouched.
+
+def _configure_test_resources(
+    cls,
+    config: StackConfig,
+    flags: dict[str, str] | None,
+) -> None:
+    """Resolve and save every spec in cls.test_resources, applying the test_only safety guard.
+
+    Parameters
+    ----------
+    cls
+        The package's PackageConfigBase subclass, whose test_resources are resolved.
+    config : StackConfig
+        The current StackConfig, updated in place with each resolved test resource.
+    flags : dict[str, str] or None
+        ``--test-*`` flag values, keyed by field name (without the test- prefix).
+        None means this came from the interactive confirm-driven flow instead.
+
+    Notes
+    -----
+    Shared by both the interactive confirm-driven flow and the non-interactive
+    ``--test-*`` flag flow. The safety checks (test_only marking, production
+    collision detection) must hold identically in both.
+    """
+    test_names = {s.semantic_name for s in cls.test_resources}
+    for spec in cls.test_resources:
+        result = _resolve_resource(spec, config, flags=flags, is_test_resource=True)
+        if result is None:
+            continue
+        db_label, new_db, new_resource = result
+
+        if new_db is not None:
+            # New connection: set test_only flag and check for production collision.
+            new_db.test_only = True
+            for res_name, existing_res in config.resources.items():
+                if res_name in test_names:
                     continue
-                db_label, new_db, new_resource = result
-
-                if new_db is not None:
-                    # New connection: set test_only flag and check for production collision.
-                    new_db.test_only = True
-                    for res_name, existing_res in config.resources.items():
-                        if res_name in test_names:
-                            continue
-                        existing_conn = config.databases.get(existing_res.database)
-                        if existing_conn is None or existing_conn.test_only:
-                            continue
-                        if (
-                            existing_conn.host == new_db.host
-                            and existing_conn.database_name == new_db.database_name
-                            and existing_conn.port == new_db.port
-                        ):
-                            err_console.print(
-                                f"\n[red bold]DANGER[/red bold]: these connection details match the"
-                                f" [bold]{res_name!r}[/bold] resource (same host and database name).\n"
-                                f"Tests run DROP SCHEMA CASCADE — this would destroy your data.\n"
-                                f"Use a different [bold]host[/bold] or [bold]database name[/bold]."
-                            )
-                            raise typer.Exit(1)
-                    config.databases[db_label] = new_db
-                else:
-                    # Reuse: verify the referenced connection is actually test_only.
-                    existing_db = config.databases.get(db_label)
-                    if existing_db is not None and not existing_db.test_only:
-                        err_console.print(
-                            f"\n[red bold]DANGER[/red bold]: the connection {db_label!r} is not"
-                            f" marked test_only=true. Point test resources only to test_only"
-                            f" connections.\n"
-                        )
-                        raise typer.Exit(1)
-
-                config.resources[spec.semantic_name] = new_resource
-                save_stack_config(config)
-                console.print(
-                    f"[green]✓[/green] Test resource [bold]{spec.semantic_name!r}[/bold] written."
+                existing_conn = config.databases.get(existing_res.database)
+                if existing_conn is None or existing_conn.test_only:
+                    continue
+                if (
+                    existing_conn.host == new_db.host
+                    and existing_conn.database_name == new_db.database_name
+                    and existing_conn.port == new_db.port
+                ):
+                    err_console.print(
+                        f"\n[red bold]DANGER[/red bold]: these connection details match the"
+                        f" [bold]{res_name!r}[/bold] resource (same host and database name).\n"
+                        f"Tests run DROP SCHEMA CASCADE, which would destroy your data.\n"
+                        f"Use a different [bold]host[/bold] or [bold]database name[/bold]."
+                    )
+                    raise typer.Exit(1)
+            config.databases[db_label] = new_db
+        else:
+            # Reuse: verify the referenced connection is actually test_only.
+            existing_db = config.databases.get(db_label)
+            if existing_db is not None and not existing_db.test_only:
+                err_console.print(
+                    f"\n[red bold]DANGER[/red bold]: the connection {db_label!r} is not"
+                    f" marked test_only=true. Point test resources only to test_only"
+                    f" connections.\n"
                 )
+                raise typer.Exit(1)
+
+        config.resources[spec.semantic_name] = new_resource
+        save_stack_config(config)
+        console.print(
+            f"[green]✓[/green] Test resource [bold]{spec.semantic_name!r}[/bold] written."
+        )
 
 @app.callback()  # required by Typer to attach global --verbose/-v before any subcommand
 def _main(

--- a/src/oa_configurator/cli_fields.py
+++ b/src/oa_configurator/cli_fields.py
@@ -1,0 +1,322 @@
+from dataclasses import dataclass
+from typing import Callable
+
+import click
+import typer
+
+from .models import ResourceConfig, DatabaseConfig
+from .package_base import ResourceSpec
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """Definition for a single CLI field (e.g. a DatabaseConfig or ResourceConfig field).
+
+    Parameters
+    ----------
+    name : str
+        The name of the field, matching a DatabaseConfig/ResourceConfig field.
+    label : str
+        A human friendly label for the field, shown in interactive prompts and --help text.
+    default : str or Callable[[ResourceSpec], str], optional
+        A default value for the field, used as the prompt default and non-interactive
+        fallback. If a callable is given, it is called with the ResourceSpec to derive
+        a default value.
+    nullable : bool, default True
+        Whether the field can be null. If False, an empty resolved value is treated as
+        an error in non-interactive mode. See resolve_fields.
+    hide_input : bool, default False
+        Whether to hide input when prompting for this field (e.g. for passwords).
+    """
+
+    name: str
+    label: str
+    default: str | Callable[[ResourceSpec], str] = ""
+    nullable: bool = True
+    hide_input: bool = False
+
+
+# -------------------
+# Database connection
+# -------------------
+FS_DATABASE = FieldSpec(
+    "database",
+    "Database label (short name for this database entry, e.g. 'cdm')",
+    default=lambda spec: spec.connection_name_hint or spec.semantic_name,
+    nullable=False,
+)
+FS_DIALECT = FieldSpec(
+    "dialect",
+    "Dialect (SQLAlchemy driver string, e.g. postgresql+psycopg, sqlite)",
+    nullable=False,
+)
+FS_HOST = FieldSpec(
+    "host",
+    "Host (e.g. Docker container name)",
+    default="localhost",
+    nullable=False,
+)
+FS_PORT = FieldSpec(
+    "port",
+    "Port (leave blank to use the dialect default)",
+)
+FS_USER = FieldSpec(
+    "user",
+    "User (leave blank if not required)",
+)
+FS_PASSWORD = FieldSpec(
+    "password",
+    "Password (leave blank if not required)",
+    hide_input=True,
+)
+FS_DATABASE_NAME = FieldSpec(
+    "database_name",
+    "Database name (name of the database on the server, or file path for SQLite)",
+    nullable=False,
+)
+
+DATABASE_LABEL_FIELDS: tuple[FieldSpec, ...] = (
+    FS_DATABASE,
+    FS_DIALECT,
+    FS_HOST,
+    FS_PORT,
+    FS_USER,
+    FS_PASSWORD,
+    FS_DATABASE_NAME,
+)
+
+# --------------------
+# Schema configuration
+# --------------------
+FS_CDM_SCHEMA = FieldSpec(
+    "cdm_schema",
+    "CDM schema (schema containing the OMOP tables)",
+    default=lambda spec: spec.cdm_schema_default,
+    nullable=False,
+)
+FS_VOCAB_SCHEMA = FieldSpec(
+    "vocab_schema",
+    "Vocab schema (blank = same schema as CDM; set only if vocabulary lives in a separate schema)",
+)
+FS_RESULTS_SCHEMA = FieldSpec(
+    "results_schema",
+    "Results schema (for Achilles/Atlas results tables; blank = not used)",
+)
+FS_NON_CDM_SCHEMA = FieldSpec(
+    FS_CDM_SCHEMA.name,
+    "Schema (leave blank for public/default)",
+    default=lambda spec: spec.cdm_schema_default,
+    nullable=False,
+)
+CDM_SCHEMA_FIELDS = (FS_CDM_SCHEMA, FS_VOCAB_SCHEMA, FS_RESULTS_SCHEMA)
+NON_CDM_SCHEMA_FIELDS = (FS_NON_CDM_SCHEMA,)
+
+
+def resolve_field_value(
+    field_name: str,
+    *,
+    prompt_label: str,
+    default_value: str,
+    flags: dict[str, str],
+    stored: dict[str, str],
+    spec_defaults: dict[str, str] | None,
+    non_interactive: bool,
+    missing_required: list[str],
+    required: bool = False,
+    hide_input: bool = False,
+) -> str:
+    """Resolve one field's value.
+
+    Parameters
+    ----------
+    field_name : str
+        The field name to resolve, used to look it up in flags/stored/spec_defaults.
+    prompt_label : str
+        The label shown to the user in an interactive prompt.
+    default_value : str
+        The value shown (and accepted on Enter) in an interactive prompt, and the
+        silent non-interactive fallback when nothing else supplied a value.
+    flags : dict[str, str]
+        Explicit CLI flag values, keyed by field name. Checked first.
+    stored : dict[str, str]
+        Values already stored in config.toml for this resource. Checked second.
+    spec_defaults : dict[str, str] or None
+        Package-supplied defaults for this resource (ResourceSpec.defaults). Checked third.
+    non_interactive : bool
+        Whether to skip prompting and fall back to default_value instead.
+    missing_required : list[str]
+        Mutable list that field_name is appended to when required is True,
+        non_interactive is True, and nothing else resolved a value.
+    required : bool, default False
+        Whether this field has no usable fallback. Computed by resolve_fields; should
+        not be set by hand elsewhere.
+    hide_input : bool, default False
+        Whether to hide input when prompting (e.g. for passwords).
+
+    Returns
+    -------
+    str
+        The resolved value: explicit flag, then stored config, then spec default,
+        then either an interactive prompt or, non-interactively, default_value.
+    """
+    if (val := flags.get(field_name)) is not None:
+        return str(val)
+    if field_name in stored:
+        return stored[field_name]
+    if spec_defaults and (pre := spec_defaults.get(field_name)) is not None:
+        return str(pre)
+    if non_interactive:
+        if required:
+            missing_required.append(field_name)
+        return default_value
+    return typer.prompt(prompt_label, default=default_value, hide_input=hide_input)
+
+
+def resolve_fields(
+    fields: tuple[FieldSpec, ...],
+    spec: ResourceSpec,
+    resolve_field_fn: Callable[..., str],
+) -> dict[str, str | None]:
+    """Resolve a whole field table at once via resolve (a resolve_field_value partial).
+
+    Parameters
+    ----------
+    fields : tuple[FieldSpec, ...]
+        The field table to resolve, e.g. DATABASE_LABEL_FIELDS.
+    spec : ResourceSpec
+        The resource being configured, passed to any callable FieldSpec.default.
+    resolve_field_fn : Callable[..., str]
+        A resolve_field_value partial, pre-bound with flags/stored/spec_defaults/etc.
+
+    Returns
+    -------
+    dict[str, str or None]
+        One entry per field, keyed by FieldSpec.name. A field counts as required
+        (reported via resolve's missing_required list when nothing resolves it)
+        exactly when it is not nullable and has no usable default: not
+        callable(f.default) and not f.nullable and not f.default. A callable
+        default always counts as usable, since it is written to always return a
+        real value.
+    """
+    result: dict[str, str | None] = {}
+    for f in fields:
+        default = f.default(spec) if callable(f.default) else f.default
+        is_required = not callable(f.default) and not f.nullable and not f.default
+        value = resolve_field_fn(f.name, prompt_label=f.label, default_value=default, required=is_required, hide_input=f.hide_input)
+        result[f.name] = (value or None) if f.nullable else value
+    return result
+
+
+def pop_str(values: dict[str, str | None], name: str) -> str:
+    """Pop a field that resolve_fields has already guaranteed is not None.
+
+    Parameters
+    ----------
+    values : dict[str, str or None]
+        A dict produced by resolve_fields.
+    name : str
+        The field name to pop. Must be one whose FieldSpec has nullable=False.
+
+    Returns
+    -------
+    str
+        The popped value.
+    """
+    value = values.pop(name)
+    assert value is not None
+    return value
+
+
+def build_resource_params(spec: ResourceSpec, *, prefix: str = "") -> list[click.Parameter]:
+    """Generate Click options for one resource from its field tables.
+
+    Parameters
+    ----------
+    spec : ResourceSpec
+        The resource to generate flags for.
+    prefix : str, optional
+        A prefix for the flag names (e.g. "test-"), used to prevent namespace
+        collisions between a package's owned resource and its test resource, which
+        often share field names (host, port, etc.). Default: ""
+
+    Returns
+    -------
+    list[click.Parameter]
+        One click.Option per field in DATABASE_LABEL_FIELDS plus the resource's schema
+        fields (CDM_SCHEMA_FIELDS or NON_CDM_SCHEMA_FIELDS, depending on
+        spec.is_cdm_database).
+    """
+    prefixed_option = lambda n: f"--{prefix}{n.replace('_', '-')}"
+    schema_fields = CDM_SCHEMA_FIELDS if spec.is_cdm_database else NON_CDM_SCHEMA_FIELDS
+
+    return [
+        click.Option(
+            [prefixed_option(f.name)],
+            default=None,
+            type=click.STRING,
+            help=f.label,
+        )
+        for f in (*DATABASE_LABEL_FIELDS, *schema_fields)
+    ]
+
+
+def build_resource_config(
+    database: str,
+    schema_values: dict[str, str | None],
+    is_cdm_database: bool,
+) -> ResourceConfig:
+    """Build a ResourceConfig from resolve_fields output for a schema field table.
+
+    Parameters
+    ----------
+    database : str
+        The database label this resource points to.
+    schema_values : dict[str, str or None]
+        Output of resolve_fields(CDM_SCHEMA_FIELDS or NON_CDM_SCHEMA_FIELDS, ...).
+    is_cdm_database : bool
+        Whether this resource is a CDM database. Non-CDM resources have no
+        vocab_schema or results_schema.
+
+    Returns
+    -------
+    ResourceConfig
+    """
+    cdm_schema = pop_str(schema_values, FS_CDM_SCHEMA.name)
+    return ResourceConfig(
+        database=database,
+        cdm_schema=cdm_schema,
+        vocab_schema=schema_values.get(FS_VOCAB_SCHEMA.name) if is_cdm_database else None,
+        results_schema=schema_values.get(FS_RESULTS_SCHEMA.name) if is_cdm_database else None,
+    )
+
+
+def build_database_config(
+    conn_values: dict[str, str | None],
+) -> tuple[DatabaseConfig, str]:
+    """Build a DatabaseConfig from resolve_fields(DATABASE_LABEL_FIELDS, ...) output.
+
+    Parameters
+    ----------
+    conn_values : dict[str, str or None]
+        Output of resolve_fields(DATABASE_LABEL_FIELDS, ...). Must be resolved, and
+        checked for missing required fields, before this is called, since popping
+        a field with no value raises rather than reporting it.
+
+    Returns
+    -------
+    DatabaseConfig
+    str
+        The database label this config should be stored under.
+    """
+    database = pop_str(conn_values, FS_DATABASE.name)
+    dialect = pop_str(conn_values, FS_DIALECT.name)
+    raw_port = conn_values.pop(FS_PORT.name)
+    db_config = DatabaseConfig(
+        dialect=dialect,
+        host=conn_values[FS_HOST.name],
+        port=int(raw_port) if raw_port is not None else None,
+        user=conn_values[FS_USER.name],
+        password=conn_values[FS_PASSWORD.name],
+        database_name=conn_values[FS_DATABASE_NAME.name],
+    )
+    return db_config, database

--- a/src/oa_configurator/cli_fields.py
+++ b/src/oa_configurator/cli_fields.py
@@ -36,6 +36,30 @@ class FieldSpec:
     hide_input: bool = False
 
 
+TEST_FLAG_PREFIX = "test"
+
+
+def flag_name(name: str, prefix: str = "") -> str:
+    """Build a Click flag name from a field name and an optional prefix.
+
+    Parameters
+    ----------
+    name : str
+        The field name, e.g. "database_name". Underscores become hyphens.
+    prefix : str, optional
+        A prefix to insert before the field name, without a trailing hyphen
+        (e.g. "test", not "test-"). The hyphen is appended automatically when
+        prefix is non-empty. Default: ""
+
+    Returns
+    -------
+    str
+        The flag name, e.g. "--database-name" or "--test-database-name".
+    """
+    full_prefix = f"{prefix}-" if prefix else ""
+    return f"--{full_prefix}{name.replace('_', '-')}"
+
+
 # -------------------
 # Database connection
 # -------------------
@@ -141,7 +165,8 @@ def resolve_field_value(
     stored : dict[str, str]
         Values already stored in config.toml for this resource. Checked second.
     spec_defaults : dict[str, str] or None
-        Package-supplied defaults for this resource (ResourceSpec.defaults). Checked third.
+        Package-supplied defaults for this resource (ResourceSpec.connection_defaults,
+        stringified). Checked third.
     non_interactive : bool
         Whether to skip prompting and fall back to default_value instead.
     missing_required : list[str]
@@ -235,9 +260,10 @@ def build_resource_params(spec: ResourceSpec, *, prefix: str = "") -> list[click
     spec : ResourceSpec
         The resource to generate flags for.
     prefix : str, optional
-        A prefix for the flag names (e.g. "test-"), used to prevent namespace
-        collisions between a package's owned resource and its test resource, which
-        often share field names (host, port, etc.). Default: ""
+        A prefix for the flag names, without a trailing hyphen (e.g. "test", not
+        "test-"), used to prevent namespace collisions between a package's owned
+        resource and its test resource, which often share field names (host, port,
+        etc.). Default: ""
 
     Returns
     -------
@@ -246,12 +272,11 @@ def build_resource_params(spec: ResourceSpec, *, prefix: str = "") -> list[click
         fields (CDM_SCHEMA_FIELDS or NON_CDM_SCHEMA_FIELDS, depending on
         spec.is_cdm_database).
     """
-    prefixed_option = lambda n: f"--{prefix}{n.replace('_', '-')}"
     schema_fields = CDM_SCHEMA_FIELDS if spec.is_cdm_database else NON_CDM_SCHEMA_FIELDS
 
     return [
         click.Option(
-            [prefixed_option(f.name)],
+            [flag_name(f.name, prefix)],
             default=None,
             type=click.STRING,
             help=f.label,

--- a/src/oa_configurator/io.py
+++ b/src/oa_configurator/io.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import tomli_w
 
-from .loader import CONFIG_PATH, DEFAULT_CONFIG_PATH
+from .loader import CONFIG_PATH
 from .resolver import Resolver
 from .models import StackConfig
 
@@ -70,7 +70,7 @@ def write_env_file(resolver: Resolver, path: Path = FLAT_ENV_PATH) -> Path:
     return path
 
 
-def save_stack_config(config: StackConfig, path: Path = DEFAULT_CONFIG_PATH) -> Path:
+def save_stack_config(config: StackConfig, path: Path = CONFIG_PATH) -> Path:
     """Serialize a :class:`~oa_configurator.models.StackConfig` back to TOML.
 
     Does NOT preserve comments or original formatting. The ``logging`` section
@@ -90,7 +90,7 @@ def save_stack_config(config: StackConfig, path: Path = DEFAULT_CONFIG_PATH) -> 
     return path
 
 
-def patch_active_profile(profile_name: str, path: Path = DEFAULT_CONFIG_PATH) -> None:
+def patch_active_profile(profile_name: str, path: Path = CONFIG_PATH) -> None:
     """Set ``active_profile`` in the TOML file without touching other fields.
 
     Creates the file with only ``active_profile`` if it does not exist.

--- a/src/oa_configurator/models.py
+++ b/src/oa_configurator/models.py
@@ -76,7 +76,7 @@ class DatabaseConfig(BaseModel):
             drivername=self.dialect,
             username=self.user,
             password=self.password,
-            host=self.host or "localhost",
+            host=self.host,
             port=self.port,
             database=self.database_name or "",
         ).render_as_string(hide_password=hide_password)

--- a/src/oa_configurator/models.py
+++ b/src/oa_configurator/models.py
@@ -72,6 +72,11 @@ class DatabaseConfig(BaseModel):
         if self.dialect.startswith("sqlite"):
             db = self.database_name or ":memory:"
             return f"sqlite:///{db}"
+        if not self.host:
+            raise ValueError(
+                "DatabaseConfig has no `host` set and no longer defaults to 'localhost'."
+                " Set `host` explicitly in config.toml."
+            )
         return URL.create(
             drivername=self.dialect,
             username=self.user,

--- a/src/oa_configurator/models.py
+++ b/src/oa_configurator/models.py
@@ -282,9 +282,9 @@ class StackConfig(BaseModel):
         cls,
         *,
         databases: dict[str, DatabaseConfig] | None = None,
-        resources: dict | None = None,
-        tools: dict | None = None,
-        profiles: dict | None = None,
+        resources: dict[str, ResourceConfig] | None = None,
+        tools: dict[str, ToolConfig] | None = None,
+        profiles: dict[str, ProfileOverrideConfig] | None = None,
         active_profile: str | None = None,
         resource_aliases: dict[str, str] | None = None,
     ) -> StackConfig:
@@ -292,6 +292,15 @@ class StackConfig(BaseModel):
 
         Intended for tests and scripts. Cross-references are validated at
         construction time, same as for file-loaded configs.
+
+        Notes
+        -----
+        Pydantic still coerces a raw dict (e.g. one shaped like a parsed TOML
+        table) into the corresponding model at validation time, so passing
+        plain dicts keeps working at runtime. The parameter types above are
+        the strict, intended shape; prefer constructing ResourceConfig,
+        ToolConfig, and ProfileOverrideConfig instances directly so a renamed
+        field is caught by the type checker instead of only at validation time.
         """
         return cls(
             active_profile=active_profile,

--- a/src/oa_configurator/package_base.py
+++ b/src/oa_configurator/package_base.py
@@ -31,7 +31,7 @@ from typing import Any, ClassVar, Self
 
 from pydantic import BaseModel
 
-from .models import StackConfig
+from .models import DatabaseConfig, StackConfig
 
 
 @dataclass(frozen=True)
@@ -56,12 +56,11 @@ class ResourceSpec:
         When ``False``, the configure prompt skips the vocab schema and
         results schema questions — those are OMOP CDM-specific concepts that
         do not apply to other databases such as the pgvector embedding store.
-    defaults
-        Optional pre-fill values for connection prompts. Keys match
-        ``DatabaseConfig`` and ``ResourceConfig`` field names (``dialect``,
-        ``host``, ``port``, ``user``, ``password``, ``database_name``,
-        ``cdm_schema``). Applied when there is no stored config for a field
-        — lower priority than an existing stored value.
+    connection_defaults
+        Optional pre-fill values for the connection prompts (dialect, host, port,
+        user, password, database_name), as a ``DatabaseConfig`` instance. Only the
+        fields actually set are used; the rest fall through to each field's own
+        default. Applied when there is no stored config for a field.
     """
 
     semantic_name: str
@@ -70,7 +69,7 @@ class ResourceSpec:
     connection_name_hint: str = ""
     cdm_schema_default: str = "omop"
     is_cdm_database: bool = True
-    defaults: dict[str, Any] | None = field(default=None, compare=False)
+    connection_defaults: DatabaseConfig | None = field(default=None, compare=False)
 
 
 class ConfigurationError(ValueError):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,14 @@ from __future__ import annotations
 
 import pytest
 
-from oa_configurator import StackConfig, DatabaseConfig
+from oa_configurator import (
+    FS_CDM_SCHEMA,
+    FS_DATABASE,
+    FS_RESULTS_SCHEMA,
+    FS_VOCAB_SCHEMA,
+    StackConfig,
+    DatabaseConfig,
+)
 
 
 @pytest.fixture
@@ -23,8 +30,8 @@ def minimal_stack() -> StackConfig:
         },
         resources={
             "default": {
-                "database": "db",
-                "cdm_schema": "omop",
+                FS_DATABASE.name: "db",
+                FS_CDM_SCHEMA.name: "omop",
             }
         },
     )
@@ -46,10 +53,10 @@ def pg_stack() -> StackConfig:
         },
         resources={
             "default": {
-                "database": "cdm",
-                "cdm_schema": "omop",
-                "vocab_schema": "omop_vocab",
-                "results_schema": "results",
+                FS_DATABASE.name: "cdm",
+                FS_CDM_SCHEMA.name: "omop",
+                FS_VOCAB_SCHEMA.name: "omop_vocab",
+                FS_RESULTS_SCHEMA.name: "results",
             }
         },
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,9 @@ from __future__ import annotations
 import pytest
 
 from oa_configurator import (
-    FS_CDM_SCHEMA,
-    FS_DATABASE,
-    FS_RESULTS_SCHEMA,
-    FS_VOCAB_SCHEMA,
     StackConfig,
     DatabaseConfig,
+    ResourceConfig,
 )
 
 
@@ -29,10 +26,7 @@ def minimal_stack() -> StackConfig:
             )
         },
         resources={
-            "default": {
-                FS_DATABASE.name: "db",
-                FS_CDM_SCHEMA.name: "omop",
-            }
+            "default": ResourceConfig(database="db", cdm_schema="omop"),
         },
     )
 
@@ -52,11 +46,11 @@ def pg_stack() -> StackConfig:
             )
         },
         resources={
-            "default": {
-                FS_DATABASE.name: "cdm",
-                FS_CDM_SCHEMA.name: "omop",
-                FS_VOCAB_SCHEMA.name: "omop_vocab",
-                FS_RESULTS_SCHEMA.name: "results",
-            }
+            "default": ResourceConfig(
+                database="cdm",
+                cdm_schema="omop",
+                vocab_schema="omop_vocab",
+                results_schema="results",
+            ),
         },
     )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import tomllib
 
-from oa_configurator import FS_CDM_SCHEMA, FS_DATABASE, Resolver, StackConfig, DatabaseConfig
+from oa_configurator import Resolver, StackConfig, DatabaseConfig, ResourceConfig, ToolConfig
 from oa_configurator.io import patch_active_profile, save_stack_config, write_env_file
 
 
@@ -21,10 +21,7 @@ def _make_cdm_stack() -> StackConfig:
             )
         },
         resources={
-            "default": {
-                FS_DATABASE.name: "cdm",
-                FS_CDM_SCHEMA.name: "omop",
-            }
+            "default": ResourceConfig(database="cdm", cdm_schema="omop"),
         },
     )
 
@@ -74,11 +71,11 @@ class TestWriteEnvFile:
                 "emb": DatabaseConfig(dialect="postgresql+psycopg", host="emb.host", port=5433, user="eu", password="ep", database_name="embeddings"),
             },
             resources={
-                "default": {FS_DATABASE.name: "cdm", FS_CDM_SCHEMA.name: "omop"},
-                "omop_emb": {FS_DATABASE.name: "emb", FS_CDM_SCHEMA.name: "emb"},
+                "default": ResourceConfig(database="cdm", cdm_schema="omop"),
+                "omop_emb": ResourceConfig(database="emb", cdm_schema="emb"),
             },
             tools={
-                "omop_emb": {"extra": {"backend": "pgvector"}},
+                "omop_emb": ToolConfig(extra={"backend": "pgvector"}),
             },
         )
         out = tmp_path / "config.env"
@@ -90,8 +87,8 @@ class TestWriteEnvFile:
     def test_tool_extra_scalars_exported(self, tmp_path):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
-            tools={"my_pkg": {"extra": {"foo": "bar", "count": 3}}},
+            resources={"default": ResourceConfig(database="db", cdm_schema="omop")},
+            tools={"my_pkg": ToolConfig(extra={"foo": "bar", "count": 3})},
         )
         out = tmp_path / "config.env"
         write_env_file(Resolver(cfg), path=out)
@@ -108,7 +105,7 @@ class TestSaveStackConfig:
     def test_creates_file(self, tmp_path):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
+            resources={"default": ResourceConfig(database="db", cdm_schema="omop")},
         )
         out = tmp_path / "config.toml"
         save_stack_config(cfg, out)
@@ -119,7 +116,7 @@ class TestSaveStackConfig:
             databases={
                 "cdm": DatabaseConfig(dialect="postgresql+psycopg", host="localhost", port=5432, user="omop", password="pass", database_name="omop_cdm")
             },
-            resources={"default": {FS_DATABASE.name: "cdm", FS_CDM_SCHEMA.name: "omop"}},
+            resources={"default": ResourceConfig(database="cdm", cdm_schema="omop")},
         )
         out = tmp_path / "config.toml"
         save_stack_config(cfg, out)
@@ -135,7 +132,7 @@ class TestSaveStackConfig:
     def test_none_values_stripped(self, tmp_path):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite")},
-            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
+            resources={"default": ResourceConfig(database="db", cdm_schema="omop")},
         )
         out = tmp_path / "config.toml"
         save_stack_config(cfg, out)
@@ -157,7 +154,7 @@ class TestPatchActiveProfile:
     def test_updates_existing_file(self, tmp_path):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite")},
-            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
+            resources={"default": ResourceConfig(database="db", cdm_schema="omop")},
         )
         out = tmp_path / "config.toml"
         save_stack_config(cfg, out)
@@ -169,7 +166,7 @@ class TestPatchActiveProfile:
     def test_does_not_touch_other_fields(self, tmp_path):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite")},
-            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
+            resources={"default": ResourceConfig(database="db", cdm_schema="omop")},
             active_profile="dev",
         )
         out = tmp_path / "config.toml"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import tomllib
 
-from oa_configurator import Resolver, StackConfig, DatabaseConfig
+from oa_configurator import FS_CDM_SCHEMA, FS_DATABASE, Resolver, StackConfig, DatabaseConfig
 from oa_configurator.io import patch_active_profile, save_stack_config, write_env_file
 
 
@@ -22,8 +22,8 @@ def _make_cdm_stack() -> StackConfig:
         },
         resources={
             "default": {
-                "database": "cdm",
-                "cdm_schema": "omop",
+                FS_DATABASE.name: "cdm",
+                FS_CDM_SCHEMA.name: "omop",
             }
         },
     )
@@ -74,8 +74,8 @@ class TestWriteEnvFile:
                 "emb": DatabaseConfig(dialect="postgresql+psycopg", host="emb.host", port=5433, user="eu", password="ep", database_name="embeddings"),
             },
             resources={
-                "default": {"database": "cdm", "cdm_schema": "omop"},
-                "omop_emb": {"database": "emb", "cdm_schema": "emb"},
+                "default": {FS_DATABASE.name: "cdm", FS_CDM_SCHEMA.name: "omop"},
+                "omop_emb": {FS_DATABASE.name: "emb", FS_CDM_SCHEMA.name: "emb"},
             },
             tools={
                 "omop_emb": {"extra": {"backend": "pgvector"}},
@@ -90,7 +90,7 @@ class TestWriteEnvFile:
     def test_tool_extra_scalars_exported(self, tmp_path):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"default": {"database": "db", "cdm_schema": "omop"}},
+            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
             tools={"my_pkg": {"extra": {"foo": "bar", "count": 3}}},
         )
         out = tmp_path / "config.env"
@@ -108,7 +108,7 @@ class TestSaveStackConfig:
     def test_creates_file(self, tmp_path):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"default": {"database": "db", "cdm_schema": "omop"}},
+            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
         )
         out = tmp_path / "config.toml"
         save_stack_config(cfg, out)
@@ -119,7 +119,7 @@ class TestSaveStackConfig:
             databases={
                 "cdm": DatabaseConfig(dialect="postgresql+psycopg", host="localhost", port=5432, user="omop", password="pass", database_name="omop_cdm")
             },
-            resources={"default": {"database": "cdm", "cdm_schema": "omop"}},
+            resources={"default": {FS_DATABASE.name: "cdm", FS_CDM_SCHEMA.name: "omop"}},
         )
         out = tmp_path / "config.toml"
         save_stack_config(cfg, out)
@@ -135,7 +135,7 @@ class TestSaveStackConfig:
     def test_none_values_stripped(self, tmp_path):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite")},
-            resources={"default": {"database": "db", "cdm_schema": "omop"}},
+            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
         )
         out = tmp_path / "config.toml"
         save_stack_config(cfg, out)
@@ -157,7 +157,7 @@ class TestPatchActiveProfile:
     def test_updates_existing_file(self, tmp_path):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite")},
-            resources={"default": {"database": "db", "cdm_schema": "omop"}},
+            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
         )
         out = tmp_path / "config.toml"
         save_stack_config(cfg, out)
@@ -169,7 +169,7 @@ class TestPatchActiveProfile:
     def test_does_not_touch_other_fields(self, tmp_path):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite")},
-            resources={"default": {"database": "db", "cdm_schema": "omop"}},
+            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
             active_profile="dev",
         )
         out = tmp_path / "config.toml"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from oa_configurator import DatabaseConfig, ResourceConfig, StackConfig, ToolConfig
+from oa_configurator import FS_CDM_SCHEMA, FS_DATABASE, DatabaseConfig, ResourceConfig, StackConfig, ToolConfig
 
 
 class TestDatabaseConfig:
@@ -90,7 +90,7 @@ class TestStackConfig:
     def test_for_session_accepts_raw_dicts(self):
         cfg = StackConfig.for_session(
             databases={"c": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"r": {"database": "c", "cdm_schema": "s"}},
+            resources={"r": {FS_DATABASE.name: "c", FS_CDM_SCHEMA.name: "s"}},
         )
         assert isinstance(cfg.databases["c"], DatabaseConfig)
         assert isinstance(cfg.resources["r"], ResourceConfig)
@@ -99,7 +99,7 @@ class TestStackConfig:
         with pytest.raises(ValueError, match="unknown database"):
             StackConfig.for_session(
                 databases={},
-                resources={"r": {"database": "missing", "cdm_schema": "s"}},
+                resources={"r": {FS_DATABASE.name: "missing", FS_CDM_SCHEMA.name: "s"}},
             )
 
     def test_cross_ref_validation_unknown_resource_in_tool(self):
@@ -114,17 +114,17 @@ class TestStackConfig:
         with pytest.raises(ValueError, match="unknown database"):
             StackConfig.for_session(
                 databases={"c": DatabaseConfig(dialect="sqlite")},
-                resources={"r": {"database": "c", "vocab_database": "missing", "cdm_schema": "s"}},
+                resources={"r": {FS_DATABASE.name: "c", "vocab_database": "missing", FS_CDM_SCHEMA.name: "s"}},
             )
 
     def test_profile_overlay_cross_ref(self):
         cfg = StackConfig.for_session(
             databases={"c": DatabaseConfig(dialect="sqlite")},
-            resources={"r": {"database": "c", "cdm_schema": "s"}},
+            resources={"r": {FS_DATABASE.name: "c", FS_CDM_SCHEMA.name: "s"}},
             profiles={
                 "test": {
                     "databases": {"tc": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-                    "resources": {"r": {"database": "tc", "cdm_schema": "s"}},
+                    "resources": {"r": {FS_DATABASE.name: "tc", FS_CDM_SCHEMA.name: "s"}},
                 }
             }
         )
@@ -134,10 +134,10 @@ class TestStackConfig:
         with pytest.raises(ValueError, match="unknown database"):
             StackConfig.for_session(
                 databases={"c": DatabaseConfig(dialect="sqlite")},
-                resources={"r": {"database": "c", "cdm_schema": "s"}},
+                resources={"r": {FS_DATABASE.name: "c", FS_CDM_SCHEMA.name: "s"}},
                 profiles={
                     "bad": {
-                        "resources": {"r": {"database": "nonexistent", "cdm_schema": "s"}},
+                        "resources": {"r": {FS_DATABASE.name: "nonexistent", FS_CDM_SCHEMA.name: "s"}},
                     }
                 },
             )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import pytest
 
-from oa_configurator import FS_CDM_SCHEMA, FS_DATABASE, DatabaseConfig, ResourceConfig, StackConfig, ToolConfig
+from oa_configurator import DatabaseConfig, ResourceConfig, StackConfig, ToolConfig
+from oa_configurator.models import ProfileOverrideConfig
 
 
 class TestDatabaseConfig:
@@ -88,9 +89,10 @@ class TestStackConfig:
         assert "default" in minimal_stack.resources
 
     def test_for_session_accepts_raw_dicts(self):
+        """Raw, TOML-table-shaped dicts (not ResourceConfig instances) still coerce at validation time."""
         cfg = StackConfig.for_session(
             databases={"c": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"r": {FS_DATABASE.name: "c", FS_CDM_SCHEMA.name: "s"}},
+            resources={"r": {"database": "c", "cdm_schema": "s"}},  # type: ignore[dict-item]
         )
         assert isinstance(cfg.databases["c"], DatabaseConfig)
         assert isinstance(cfg.resources["r"], ResourceConfig)
@@ -99,7 +101,7 @@ class TestStackConfig:
         with pytest.raises(ValueError, match="unknown database"):
             StackConfig.for_session(
                 databases={},
-                resources={"r": {FS_DATABASE.name: "missing", FS_CDM_SCHEMA.name: "s"}},
+                resources={"r": ResourceConfig(database="missing", cdm_schema="s")},
             )
 
     def test_cross_ref_validation_unknown_resource_in_tool(self):
@@ -107,26 +109,26 @@ class TestStackConfig:
             StackConfig.for_session(
                 databases={"c": DatabaseConfig(dialect="sqlite")},
                 resources={},
-                tools={"t": {"default_resource": "missing"}},
+                tools={"t": ToolConfig(default_resource="missing")},
             )
 
     def test_cross_ref_validation_vocab_database(self):
         with pytest.raises(ValueError, match="unknown database"):
             StackConfig.for_session(
                 databases={"c": DatabaseConfig(dialect="sqlite")},
-                resources={"r": {FS_DATABASE.name: "c", "vocab_database": "missing", FS_CDM_SCHEMA.name: "s"}},
+                resources={"r": ResourceConfig(database="c", vocab_database="missing", cdm_schema="s")},
             )
 
     def test_profile_overlay_cross_ref(self):
         cfg = StackConfig.for_session(
             databases={"c": DatabaseConfig(dialect="sqlite")},
-            resources={"r": {FS_DATABASE.name: "c", FS_CDM_SCHEMA.name: "s"}},
+            resources={"r": ResourceConfig(database="c", cdm_schema="s")},
             profiles={
-                "test": {
-                    "databases": {"tc": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-                    "resources": {"r": {FS_DATABASE.name: "tc", FS_CDM_SCHEMA.name: "s"}},
-                }
-            }
+                "test": ProfileOverrideConfig(
+                    databases={"tc": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
+                    resources={"r": ResourceConfig(database="tc", cdm_schema="s")},
+                ),
+            },
         )
         assert "tc" in cfg.profiles["test"].databases
 
@@ -134,11 +136,11 @@ class TestStackConfig:
         with pytest.raises(ValueError, match="unknown database"):
             StackConfig.for_session(
                 databases={"c": DatabaseConfig(dialect="sqlite")},
-                resources={"r": {FS_DATABASE.name: "c", FS_CDM_SCHEMA.name: "s"}},
+                resources={"r": ResourceConfig(database="c", cdm_schema="s")},
                 profiles={
-                    "bad": {
-                        "resources": {"r": {FS_DATABASE.name: "nonexistent", FS_CDM_SCHEMA.name: "s"}},
-                    }
+                    "bad": ProfileOverrideConfig(
+                        resources={"r": ResourceConfig(database="nonexistent", cdm_schema="s")},
+                    ),
                 },
             )
 

--- a/tests/test_package_base.py
+++ b/tests/test_package_base.py
@@ -8,12 +8,13 @@ import pytest
 
 from oa_configurator import (
     ConfigurationError,
-    FS_CDM_SCHEMA,
-    FS_DATABASE,
     PackageConfigBase,
     StackConfig,
     DatabaseConfig,
+    ResourceConfig,
+    ToolConfig,
 )
+from oa_configurator.models import ProfileOverrideConfig
 
 
 class SampleConfig(PackageConfigBase):
@@ -25,7 +26,7 @@ class SampleConfig(PackageConfigBase):
 class TestPackageConfigBase:
     def test_from_stack_reads_extra(self):
         cfg = StackConfig.for_session(
-            tools={"sample_tool": {"extra": {"backend": "custom", "file_path": "/data"}}}
+            tools={"sample_tool": ToolConfig(extra={"backend": "custom", "file_path": "/data"})}
         )
         sample = SampleConfig.from_stack(cfg)
         assert sample.backend == "custom"
@@ -39,7 +40,7 @@ class TestPackageConfigBase:
 
     def test_from_stack_uses_defaults_when_extra_empty(self):
         cfg = StackConfig.for_session(
-            tools={"sample_tool": {"extra": {}}}
+            tools={"sample_tool": ToolConfig(extra={})}
         )
         sample = SampleConfig.from_stack(cfg)
         assert sample.backend == "default_backend"
@@ -59,7 +60,7 @@ class TestPackageConfigBase:
         original = SampleConfig(backend="sqlitevec", file_path="/embeddings")
         extra = original.to_extra_dict()
         cfg = StackConfig.for_session(
-            tools={"sample_tool": {"extra": extra}}
+            tools={"sample_tool": ToolConfig(extra=extra)}
         )
         restored = SampleConfig.from_stack(cfg)
         assert restored.backend == "sqlitevec"
@@ -83,7 +84,7 @@ class TestRequiredResources:
     def test_passes_when_resource_present(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"cdm_db": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "main"}},
+            resources={"cdm_db": ResourceConfig(database="db", cdm_schema="main")},
         )
         result = RequiredConfig.from_stack(cfg)
         assert result.value == "default_value"
@@ -107,7 +108,7 @@ class TestRequiredResources:
     def test_passes_when_resource_aliased(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"my_prod": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "main"}},
+            resources={"my_prod": ResourceConfig(database="db", cdm_schema="main")},
             resource_aliases={"cdm_db": "my_prod"},
         )
         result = RequiredConfig.from_stack(cfg)
@@ -116,8 +117,8 @@ class TestRequiredResources:
     def test_respects_default_resource_override(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"my_custom": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "main"}},
-            tools={"required_tool": {"default_resource": "my_custom"}},
+            resources={"my_custom": ResourceConfig(database="db", cdm_schema="main")},
+            tools={"required_tool": ToolConfig(default_resource="my_custom")},
         )
         result = RequiredConfig.from_stack(cfg)
         assert result.value == "default_value"
@@ -126,9 +127,9 @@ class TestRequiredResources:
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
             profiles={
-                "test": {
-                    "resources": {"cdm_db": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "test_schema"}}
-                }
+                "test": ProfileOverrideConfig(
+                    resources={"cdm_db": ResourceConfig(database="db", cdm_schema="test_schema")},
+                ),
             },
             active_profile="test",
         )

--- a/tests/test_package_base.py
+++ b/tests/test_package_base.py
@@ -6,7 +6,14 @@ from typing import ClassVar
 
 import pytest
 
-from oa_configurator import ConfigurationError, PackageConfigBase, StackConfig, DatabaseConfig
+from oa_configurator import (
+    ConfigurationError,
+    FS_CDM_SCHEMA,
+    FS_DATABASE,
+    PackageConfigBase,
+    StackConfig,
+    DatabaseConfig,
+)
 
 
 class SampleConfig(PackageConfigBase):
@@ -76,7 +83,7 @@ class TestRequiredResources:
     def test_passes_when_resource_present(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"cdm_db": {"database": "db", "cdm_schema": "main"}},
+            resources={"cdm_db": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "main"}},
         )
         result = RequiredConfig.from_stack(cfg)
         assert result.value == "default_value"
@@ -100,7 +107,7 @@ class TestRequiredResources:
     def test_passes_when_resource_aliased(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"my_prod": {"database": "db", "cdm_schema": "main"}},
+            resources={"my_prod": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "main"}},
             resource_aliases={"cdm_db": "my_prod"},
         )
         result = RequiredConfig.from_stack(cfg)
@@ -109,7 +116,7 @@ class TestRequiredResources:
     def test_respects_default_resource_override(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"my_custom": {"database": "db", "cdm_schema": "main"}},
+            resources={"my_custom": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "main"}},
             tools={"required_tool": {"default_resource": "my_custom"}},
         )
         result = RequiredConfig.from_stack(cfg)
@@ -120,7 +127,7 @@ class TestRequiredResources:
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
             profiles={
                 "test": {
-                    "resources": {"cdm_db": {"database": "db", "cdm_schema": "test_schema"}}
+                    "resources": {"cdm_db": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "test_schema"}}
                 }
             },
             active_profile="test",

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from oa_configurator import Resolver, StackConfig
+from oa_configurator import FS_CDM_SCHEMA, FS_DATABASE, Resolver, StackConfig
 from oa_configurator.resolver import ResolvedDatabaseTarget, ResolvedResource
 from oa_configurator.models import DatabaseConfig
 
@@ -32,7 +32,7 @@ class TestResolveDatabase:
     def test_profile_database_takes_precedence(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name="/base.db")},
-            resources={"default": {"database": "db", "cdm_schema": "omop"}},
+            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
             profiles={
                 "test": {
                     "databases": {"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
@@ -66,9 +66,9 @@ class TestResolveResource:
             },
             resources={
                 "default": {
-                    "database": "cdm",
+                    FS_DATABASE.name: "cdm",
                     "vocab_database": "vocab",
-                    "cdm_schema": "omop",
+                    FS_CDM_SCHEMA.name: "omop",
                 }
             },
         )
@@ -95,11 +95,11 @@ class TestResolveResource:
     def test_profile_resource_takes_precedence(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"default": {"database": "db", "cdm_schema": "base_schema"}},
+            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "base_schema"}},
             profiles={
                 "test": {
                     "resources": {
-                        "default": {"database": "db", "cdm_schema": "test_schema"}
+                        "default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "test_schema"}
                     }
                 }
             },
@@ -137,7 +137,7 @@ class TestResolveTool:
     def test_tool_extra_dict(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite")},
-            resources={"default": {"database": "db", "cdm_schema": "omop"}},
+            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
             tools={"omop_emb": {"extra": {"backend": "sqlitevec", "path": "/data"}}},
         )
         r = Resolver(cfg)
@@ -183,7 +183,7 @@ class TestResourceAliases:
     def test_alias_resolves_resource(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"my_prod": {"database": "db", "cdm_schema": "main"}},
+            resources={"my_prod": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "main"}},
             resource_aliases={"cdm_db": "my_prod"},
         )
         r = Resolver(cfg)
@@ -194,10 +194,10 @@ class TestResourceAliases:
     def test_alias_with_profile_override(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"my_prod": {"database": "db", "cdm_schema": "base"}},
+            resources={"my_prod": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "base"}},
             profiles={
                 "test": {
-                    "resources": {"my_prod": {"database": "db", "cdm_schema": "test_schema"}}
+                    "resources": {"my_prod": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "test_schema"}}
                 }
             },
             resource_aliases={"cdm_db": "my_prod"},

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from oa_configurator import FS_CDM_SCHEMA, FS_DATABASE, Resolver, StackConfig
+from oa_configurator import Resolver, StackConfig
 from oa_configurator.resolver import ResolvedDatabaseTarget, ResolvedResource
-from oa_configurator.models import DatabaseConfig
+from oa_configurator.models import DatabaseConfig, ProfileOverrideConfig, ResourceConfig, ToolConfig
 
 
 class TestResolveDatabase:
@@ -32,11 +32,11 @@ class TestResolveDatabase:
     def test_profile_database_takes_precedence(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name="/base.db")},
-            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
+            resources={"default": ResourceConfig(database="db", cdm_schema="omop")},
             profiles={
-                "test": {
-                    "databases": {"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-                }
+                "test": ProfileOverrideConfig(
+                    databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
+                ),
             },
             active_profile="test",
         )
@@ -65,11 +65,7 @@ class TestResolveResource:
                 "vocab": DatabaseConfig(dialect="sqlite", database_name=":memory:"),
             },
             resources={
-                "default": {
-                    FS_DATABASE.name: "cdm",
-                    "vocab_database": "vocab",
-                    FS_CDM_SCHEMA.name: "omop",
-                }
+                "default": ResourceConfig(database="cdm", vocab_database="vocab", cdm_schema="omop"),
             },
         )
         r = Resolver(cfg)
@@ -95,13 +91,11 @@ class TestResolveResource:
     def test_profile_resource_takes_precedence(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "base_schema"}},
+            resources={"default": ResourceConfig(database="db", cdm_schema="base_schema")},
             profiles={
-                "test": {
-                    "resources": {
-                        "default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "test_schema"}
-                    }
-                }
+                "test": ProfileOverrideConfig(
+                    resources={"default": ResourceConfig(database="db", cdm_schema="test_schema")},
+                ),
             },
             active_profile="test",
         )
@@ -137,8 +131,8 @@ class TestResolveTool:
     def test_tool_extra_dict(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite")},
-            resources={"default": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "omop"}},
-            tools={"omop_emb": {"extra": {"backend": "sqlitevec", "path": "/data"}}},
+            resources={"default": ResourceConfig(database="db", cdm_schema="omop")},
+            tools={"omop_emb": ToolConfig(extra={"backend": "sqlitevec", "path": "/data"})},
         )
         r = Resolver(cfg)
         tool = r.resolve_tool("omop_emb")
@@ -183,7 +177,7 @@ class TestResourceAliases:
     def test_alias_resolves_resource(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"my_prod": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "main"}},
+            resources={"my_prod": ResourceConfig(database="db", cdm_schema="main")},
             resource_aliases={"cdm_db": "my_prod"},
         )
         r = Resolver(cfg)
@@ -194,11 +188,11 @@ class TestResourceAliases:
     def test_alias_with_profile_override(self):
         cfg = StackConfig.for_session(
             databases={"db": DatabaseConfig(dialect="sqlite", database_name=":memory:")},
-            resources={"my_prod": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "base"}},
+            resources={"my_prod": ResourceConfig(database="db", cdm_schema="base")},
             profiles={
-                "test": {
-                    "resources": {"my_prod": {FS_DATABASE.name: "db", FS_CDM_SCHEMA.name: "test_schema"}}
-                }
+                "test": ProfileOverrideConfig(
+                    resources={"my_prod": ResourceConfig(database="db", cdm_schema="test_schema")},
+                ),
             },
             resource_aliases={"cdm_db": "my_prod"},
             active_profile="test",


### PR DESCRIPTION
## Summary

`omop-config configure <pkg>` could not be configured non-interactively at all when the package declared `test_resources`: it aborted on an unconditional confirmation prompt, and even once unblocked, there was no flag-based way to populate test-resource fields in the first place. 
Bundled in: `save_stack_config`/`patch_active_profile` silently ignored `OA_CONFIG_PATH` when called without an explicit path, found while building the CI provisioning step that exercises this fix end to end.

- Fixes #6
- Fixes #8
- Fixes #9

## Root cause

Every prompt in `_run_configure_package`/`_resolve_resource` was gated behind `flags_arg is None` except the "Configure a test database resource?" confirmation, which was unconditional.
With no TTY, `typer.confirm()` hit EOF and raised `Abort` the moment that prompt was reached, after the package's main resource had already been written to disk. Even with that guarded, `_resolve_resource(..., flags=None, is_test_resource=True)` was hardcoded, so there was still no way to populate a test resource's fields non-interactively at all.

## Fixes

- **`--test-*` flag prefix centralized**:  A new `TEST_FLAG_PREFIX` constant and `flag_name(name, prefix="")` helper in `cli_fields.py` provide a single source of truth for test configurations and naming conventions. `_resolve_resource` is now also used for these test configurations similar to owned resources,  including a real error (not a silent guess) when a non-interactive call omits a field with no safe fallback.

- **`OA_CONFIG_PATH` honored everywhere** (`io.py`): `save_stack_config`/`patch_active_profile`
now default `path` to `CONFIG_PATH` (env-var-aware) instead of the hardcoded
`DEFAULT_CONFIG_PATH`.

- **Typed config construction enforced**: `StackConfig.for_session()`'s `resources`, `tools`, and `profiles` parameters are now typed as `dict[str, ResourceConfig]`, `dict[str, ToolConfig]`, and `dict[str,ProfileOverrideConfig]` respectively. The same mechanism is used for `ResourceSpec.defaults`, which is  retyped to `connection_defaults` and allows explicit typing of `connection_defaults=DatabaseConfig(dialect=..., host=..., ...)`. This allows explicit resolving through static typing instead of relying on the runtime type inference of pyright.



## Implementation notes

Supporting `--test-*` flags properly meant the per-field resolution logic needed a declarative shape it didn't have before:

- A new `cli_fields.py` module defines `FieldSpec` (name, label, default, nullable) and the field tables for connection/schema fields, and computes whether a field is required inline from `not callable(default) and not nullable and not default`, rather than tracking a separate flag, so a field can't end up both "required" and "has a working default" at once. This also unifies `--help` text and interactive prompt text onto one source (`FieldSpec.label`), which previously came from two different places. 
- The `FS_*` field-name constants are exported from the package root so downstream packages can reference
`FS_DIALECT.name`/`FS_HOST.name`/etc. instead of hardcoding the equivalent plain strings in their own `ResourceSpec.defaults` dicts

## Out of scope

This PR does not change how packages declare their `ResourceSpec`/`test_resources`.